### PR TITLE
Add moore possible changelog locations

### DIFF
--- a/packages/get-changelog-lib/src/ChangelogFinder.js
+++ b/packages/get-changelog-lib/src/ChangelogFinder.js
@@ -91,8 +91,8 @@ class ChangelogFinder {
 
         // try all possible location for changelog (with priority)
         const possibleLocations = (function() {
-            const names = ['CHANGELOG', 'changelog', 'History', 'HISTORY', 'CHANGES'];
-            const extensions = ['md'];
+            const names = ['CHANGELOG', 'changelog', 'ChangeLog', 'History', 'HISTORY', 'CHANGES'];
+            const extensions = ['md', 'txt'];
             const combinations = [];
             names.forEach(name => {
                 extensions.forEach(extension => {

--- a/packages/get-changelog-lib/src/ChangelogFinder.js
+++ b/packages/get-changelog-lib/src/ChangelogFinder.js
@@ -91,11 +91,11 @@ class ChangelogFinder {
 
         // try all possible location for changelog (with priority)
         const possibleLocations = (function() {
-            const names = ['CHANGELOG', 'changelog', 'ChangeLog', 'History', 'HISTORY', 'CHANGES'];
             const extensions = ['md', 'txt'];
+            const names = ['CHANGELOG', 'changelog', 'ChangeLog', 'History', 'HISTORY', 'CHANGES'];
             const combinations = [];
-            names.forEach(name => {
-                extensions.forEach(extension => {
+            extensions.forEach(extension => {
+                names.forEach(name => {
                     combinations.push(`${name}.${extension}`);
                 });
             });

--- a/packages/get-changelog-lib/src/ChangelogFinder.js
+++ b/packages/get-changelog-lib/src/ChangelogFinder.js
@@ -90,7 +90,17 @@ class ChangelogFinder {
         }
 
         // try all possible location for changelog (with priority)
-        const possibleLocations = ['CHANGELOG.md', 'changelog.md', 'History.md', 'HISTORY.md', 'CHANGES.md'];
+        const possibleLocations = (function() {
+            const names = ['CHANGELOG', 'changelog', 'History', 'HISTORY', 'CHANGES'];
+            const extensions = ['md'];
+            const combinations = [];
+            names.forEach(name => {
+                extensions.forEach(extension => {
+                    combinations.push(`${name}.${extension}`);
+                });
+            });
+            return combinations;
+        })();
         const defaultChangelog = `${repositoryUrl}/releases`;
         let changelog;
         for (let i = 0; i < possibleLocations.length; i++) {

--- a/packages/get-changelog-lib/src/ChangelogFinder.test.js
+++ b/packages/get-changelog-lib/src/ChangelogFinder.test.js
@@ -56,6 +56,7 @@ test('returns History.md url', async () => {
     got.mockImplementation((url) => {
         if (url === 'https://github.com/User/module-name/blob/master/CHANGELOG.md') throw new ErrorHttp(404);
         if (url === 'https://github.com/User/module-name/blob/master/changelog.md') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/ChangeLog.md') throw new ErrorHttp(404);
         if (url === 'https://github.com/User/module-name/blob/master/History.md') return 'CHANGELOG DATA';
 
         return {
@@ -83,9 +84,16 @@ test('returns github releases', async () => {
     got.mockImplementation((url) => {
         if (url === 'https://github.com/User/module-name/blob/master/CHANGELOG.md') throw new ErrorHttp(404);
         if (url === 'https://github.com/User/module-name/blob/master/changelog.md') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/ChangeLog.md') throw new ErrorHttp(404);
         if (url === 'https://github.com/User/module-name/blob/master/History.md') throw new ErrorHttp(404);
         if (url === 'https://github.com/User/module-name/blob/master/HISTORY.md') throw new ErrorHttp(404);
         if (url === 'https://github.com/User/module-name/blob/master/CHANGES.md') throw new ErrorHttp(500);
+        if (url === 'https://github.com/User/module-name/blob/master/CHANGELOG.txt') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/changelog.txt') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/ChangeLog.txt') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/History.txt') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/HISTORY.txt') throw new ErrorHttp(404);
+        if (url === 'https://github.com/User/module-name/blob/master/CHANGES.txt') throw new ErrorHttp(500);
 
         return {
             json: jest.fn().mockResolvedValue({


### PR DESCRIPTION
This PR adds more possible changelog locations.
E.g. `ChangeLog` (CamelCase) and `.txt` extension.

The below examples will be supported.
https://github.com/ajaxorg/ace-builds/blob/master/ChangeLog.txt
https://github.com/tinymce/tinymce-dist/blob/master/changelog.txt