### PR TITLE
Add option to check additional branches (FIXES #184)

### DIFF
--- a/packages/get-changelog-cli/README.md
+++ b/packages/get-changelog-cli/README.md
@@ -25,6 +25,7 @@ Options:
   -m, --module <moduleName>      get changelog for an npm module
   -r, --reporter <reporterName>  reporter to use (console, console-jira)
   -o, --open                     open changelog url with the default browser (only usable with -m)
+  -b, --branches <branches>      comma separated list of additional branches to check (e.g. -b main,test)
   --cache                        use cache to improve performances
   --txt                          try to found changelog with txt extension
   -f, --filter <matches>         (ncu option) include only package names matching the given string, comma-or-space-delimited list, or /regex/
@@ -63,6 +64,10 @@ The following reporters are implemented:
 | -------------- | ----------------------------------------------------- |
 | `console`      | (default reporter) print packages data in the console |
 | `console-jira` | print packages data in jira markup                    |
+
+#### Additional branch check
+
+By default changelog search are only performed on the `master` branch. It is possible to check additional branches (main branch for example) with the `-b` option or to add a GitHub token in order to fetch the default branch from the repository.
 
 #### GitHub token
 

--- a/packages/get-changelog-cli/bin/get-changelog
+++ b/packages/get-changelog-cli/bin/get-changelog
@@ -10,6 +10,7 @@ program
     .option('-m, --module <moduleName>', 'get changelog for an npm module')
     .option('-r, --reporter <reporterName>', 'reporter to use (console, console-jira)')
     .option('-o, --open', 'open changelog url with the default browser (only usable with -m)')
+    .option('-b, --branches <branches>', 'comma separated list of additional branches to check (e.g. -b main,test)')
     .option('--cache', 'use cache to improve performances')
     .option('--txt', 'try to found changelog with txt extension')
     .option(

--- a/packages/get-changelog-cli/src/Runner.js
+++ b/packages/get-changelog-cli/src/Runner.js
@@ -53,6 +53,7 @@ class Runner {
         const configuration = await this._parseConfiguration();
         configuration.cache = Boolean(this.options.cache);
         configuration.exploreTxtFiles = Boolean(this.options.txt);
+        configuration.branches = this.options.branches ? this.options.branches.split(',') : [];
 
         let cache;
         if (configuration.cache) {

--- a/packages/get-changelog-lib/README.md
+++ b/packages/get-changelog-lib/README.md
@@ -26,6 +26,14 @@ const ChangelogFinder = require('get-changelog-lib');
 
 ## Advanced usage
 
+#### Additional branch check
+
+By default changelog search are only performed on the `master` branch. It is possible to check additional branches (main branch for example) with the `branches` configuration field.
+
+```javascript
+const changeLogFinder = new ChangelogFinder({ branches: ['main'] }); // search changelogs in master and main branches
+```
+
 ### GitHub token
 
 Github API is used to fetch the default branch and verify releases of each repository, this API is limited to 60 requests per hours. In order to increase this rate limit it's possible to add a github token (without specific permissions) in the `CHANGELOGFINDER_GITHUB_AUTH_TOKEN` environment variable.

--- a/packages/get-changelog-lib/src/ChangelogFinder.js
+++ b/packages/get-changelog-lib/src/ChangelogFinder.js
@@ -5,16 +5,20 @@ const url = require('url');
 const GithubAPI = require('./GithubAPI');
 const specificChangelogLocations = require('../data/changelogs.json');
 
+const DEFAULT_BRANCH = 'master';
+
 class ChangelogFinder {
     /**
      * @constructor
      * @param {Object} configuration custom configuration
      * @param {Object.<string, string>} configuration.customRepositories mapping between custom repositories identifier and source path
      * @param {Boolean} configuration.exploreTxtFiles explore files with txt extension
+     * @param {Array} configuration.branches explore additional branches (only master by default)
      * @param {Cache} [cache] optional cache object
      */
     constructor(configuration, cache) {
         this.configuration = configuration || {};
+        this.configuration.branches = this.configuration.branches || [];
         this.cache = cache;
     }
 
@@ -102,34 +106,39 @@ class ChangelogFinder {
 
         const githubAPI = new GithubAPI(repositoryUrl);
 
-        let branch;
+        let branches = [DEFAULT_BRANCH, ...this.configuration.branches];
         const { host } = url.parse(repositoryUrl);
         if (host.includes('github.com') && githubAPI.isActivated()) {
-            branch = await githubAPI.getDefaultBranch();
+            const repositoryDefaultBranch = await githubAPI.getDefaultBranch();
+            branches = [repositoryDefaultBranch || DEFAULT_BRANCH];
         }
-        branch = branch || 'master';
 
-        const extensions = ['md'];
-        if (this.configuration.exploreTxtFiles) extensions.push('txt');
-
-        const names = ['CHANGELOG', 'changelog', 'ChangeLog', 'History', 'HISTORY', 'CHANGES'];
-        const possibleLocations = [];
-        extensions.forEach((extension) => {
-            names.forEach((name) => {
-                possibleLocations.push(`${name}.${extension}`);
-            });
-        });
-
-        // try all possible location for changelog (with priority)
-        const defaultChangelog = `${repositoryUrl}/releases`;
         let changelog;
-        for (let i = 0; i < possibleLocations.length; i++) {
-            changelog = await this._tryChangelogLocation(repositoryUrl, possibleLocations[i], branch);
+        for (let b = 0; b < branches.length; b++) {
+            const branch = branches[b];
+            const extensions = ['md'];
+            if (this.configuration.exploreTxtFiles) extensions.push('txt');
+
+            const names = ['CHANGELOG', 'changelog', 'ChangeLog', 'History', 'HISTORY', 'CHANGES'];
+            const possibleLocations = [];
+            extensions.forEach((extension) => {
+                names.forEach((name) => {
+                    possibleLocations.push(`${name}.${extension}`);
+                });
+            });
+
+            // try all possible location for changelog (with priority)
+            for (let i = 0; i < possibleLocations.length; i++) {
+                changelog = await this._tryChangelogLocation(repositoryUrl, possibleLocations[i], branch);
+                if (changelog) break;
+            }
+
             if (changelog) break;
         }
 
         let changelogUrl = changelog;
         if (!changelog) {
+            const defaultChangelog = `${repositoryUrl}/releases`;
             if (host.includes('github.com') && githubAPI.isActivated()) {
                 const isChangelog = await githubAPI.isReleaseChangelog(repositoryUrl);
                 changelogUrl = isChangelog ? defaultChangelog : null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add an option (`b, --branches`) to search changelog in additionnal branches.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix issues similar to #184 by letting the user check additional branches without using GitHub token.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual tests for different cases:
- (non regression) find changelog in the master branch
- (non regression) show github releases if no changelog found (with the `-b` option)
- (feature) find changelog in the main branch (with the option `-b main`)

Unit test have been updated for the new use cases.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
